### PR TITLE
remove ansible for now

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
         
-      - name: Ansible Lint
-        uses: ansible/ansible-lint-action@v6.11.0
+
         
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
         
-      - name: Ansible Lint
-        uses: ansible/ansible-lint-action@v6.11.0
-        
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
              

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
         
-      - name: Ansible Lint
-        uses: ansible/ansible-lint-action@v6.11.0
-        
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
              

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "git.enableCommitSigning": true
+    "git.enableCommitSigning": true,
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#a4adc2dd",
+        "activityBar.background": "#b0b9ceaa"
+    }
 }


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and Visual Studio Code settings. The most important changes are the removal of the Ansible Lint step from multiple workflows and the addition of custom color settings for the VS Code workbench.

GitHub Actions workflow updates:

* [`.github/workflows/cron.yml`](diffhunk://#diff-69b9772a7fe51bd7c367926862d89ca7d8949cc9832b3645e610a1ec5bfa1ddfL28-R28): Removed the Ansible Lint step from the cron job workflow.
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L28-L30): Removed the Ansible Lint step from the push event workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-L30): Removed the Ansible Lint step from the release workflow.

VS Code settings update:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2-R6): Added custom color settings for the title bar and activity bar in the VS Code workbench.

## Summary by Sourcery

This pull request removes the Ansible Lint step from the CI workflows and adds custom color settings for the VS Code workbench.

Enhancements:
- Adds custom color settings for the title bar and activity bar in the VS Code workbench.

CI:
- Removes the Ansible Lint step from the cron, push, and release workflows.